### PR TITLE
Add `get_sections` method

### DIFF
--- a/rust-uci/Cargo.toml
+++ b/rust-uci/Cargo.toml
@@ -16,3 +16,6 @@ targets = ["x86_64-unknown-linux-gnu"]
 libuci-sys = { version = "^1.1.0", path = "../libuci-sys" }
 log = "^0.4.14"
 libc = "^0.2.91"
+
+[dev-dependencies]
+tempfile = "3"

--- a/rust-uci/Cargo.toml
+++ b/rust-uci/Cargo.toml
@@ -16,7 +16,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 libuci-sys = { version = "^1.1.0", path = "../libuci-sys" }
 log = "^0.4.14"
 libc = "^0.2.91"
+thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"
-thiserror = "2"

--- a/rust-uci/src/lib.rs
+++ b/rust-uci/src/lib.rs
@@ -635,10 +635,11 @@ mod tests {
         std::fs::write(&wireless_config_path, "").unwrap();
 
         let sections = uci.get_sections("network");
-        // todo: refactor to assert_eq, once PartialEq is implemented on Error
-        println!("{sections:?}");
-        assert!(
-            matches!(sections, Err(Error::Message(str)) if str == "Could not parse uci key: network, 3, Entry not found")
-        );
+        assert_eq!(
+            sections,
+            Err(Error::EntryNotFound {
+                entry_identifier: "network".into()
+            })
+        )
     }
 }

--- a/rust-uci/src/lib.rs
+++ b/rust-uci/src/lib.rs
@@ -52,13 +52,12 @@ pub mod error;
 use core::ptr;
 use libuci_sys::{
     uci_alloc_context, uci_commit, uci_context, uci_delete, uci_element, uci_foreach_element,
-    uci_free_context, uci_get_errorstr, uci_load, uci_lookup_ptr, uci_option_type_UCI_TYPE_STRING,
+    uci_free_context, uci_get_errorstr, uci_lookup_ptr, uci_option_type_UCI_TYPE_STRING,
     uci_package, uci_ptr, uci_ptr_UCI_LOOKUP_COMPLETE, uci_revert, uci_save, uci_set,
     uci_set_confdir, uci_set_savedir, uci_to_section, uci_type_UCI_TYPE_OPTION,
     uci_type_UCI_TYPE_SECTION, uci_unload,
 };
 use log::debug;
-use std::str::FromStr;
 use std::ffi::c_int;
 use std::sync::Mutex;
 use std::{


### PR DESCRIPTION
I'm proposing to add the `get_sections` method to the `Uci` struct.

I had the following problem: I need to know all sections in a package, but I don't know the names of all the sections.
`get_sections` gives you a list of all section names.

In the process of implementing that method, I've also re-implemented some C-macros that bindgen is not able to translate to rust automatically. I've implemented them directly in the libuci-sys crate, as they are (more or less) direct translations of the C macros and don't feel particularly rusty.