### PR TITLE
Fix cargo check / clippy lints

### DIFF
--- a/libuci-sys/build.rs
+++ b/libuci-sys/build.rs
@@ -4,14 +4,14 @@
 extern crate bindgen;
 extern crate cmake;
 
-use std::{env, fs};
 use std::path::PathBuf;
+use std::{env, fs};
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
 
     // don't run cmake if running for docs.rs
-    if let Ok(_) = env::var("DOCS_RS") {
+    if env::var("DOCS_RS").is_ok() {
         fs::copy("generated/bindings.rs", out_path).unwrap();
         return;
     }

--- a/libuci-sys/src/lib.rs
+++ b/libuci-sys/src/lib.rs
@@ -36,6 +36,9 @@ pub use bindings::{
     UCI_ERR_NOTFOUND, UCI_OK,
 };
 
+#[allow(clippy::ptr_offset_with_cast)]
+#[allow(clippy::upper_case_acronyms)]
+#[allow(unnecessary_transmutes)]
 #[allow(non_upper_case_globals)]
 #[allow(non_camel_case_types)]
 #[allow(non_snake_case)]


### PR DESCRIPTION
This PR fixes some cargo check warnings and some clippy lints, as well as formatting the build.rs.