### PR TITLE
add feature to require dynamic linking to libuci

### DIFF
--- a/libuci-sys/Cargo.toml
+++ b/libuci-sys/Cargo.toml
@@ -17,3 +17,7 @@ targets = ["x86_64-unknown-linux-gnu"]
 [build-dependencies]
 bindgen = "^0.72.0"
 cmake = "^0.1.45"
+
+[features]
+# Require dynamic linking from an external libuci/libubox (no vendored build).
+require_system_libuci = []

--- a/libuci-sys/Cargo.toml
+++ b/libuci-sys/Cargo.toml
@@ -19,5 +19,6 @@ bindgen = "^0.72.0"
 cmake = "^0.1.45"
 
 [features]
-# Require dynamic linking from an external libuci/libubox (no vendored build).
-require_system_libuci = []
+# Opt into using a vendored libuci build,
+# instead of dynamically linking to an external libuci/libubox.
+vendored = []

--- a/libuci-sys/build.rs
+++ b/libuci-sys/build.rs
@@ -10,8 +10,7 @@ use std::{env, fs};
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
-    let require_system_libuci =
-        env::var_os("CARGO_FEATURE_REQUIRE_SYSTEM_LIBUCI").is_some();
+    let vendored_build = env::var_os("CARGO_FEATURE_VENDORED").is_some();
 
     // don't run cmake if running for docs.rs
     if env::var("DOCS_RS").is_ok() {
@@ -25,34 +24,39 @@ fn main() {
         builder = builder.clang_arg(format!("--target={}", bindgen_target));
     }
 
-    // if UCI_DIR is present, use it to look for the header file and precompiled libs
-    if let Ok(uci_dir) = env::var("UCI_DIR") {
-        println!("cargo:rustc-link-search=native={}/lib", uci_dir);
-        builder = builder.clang_arg(format!("-I{}/include", uci_dir));
-    } else if require_system_libuci {
-        panic!(
-            "require_system_libuci is enabled, but UCI_DIR is not set; refusing to build \
+    match vendored_build {
+        false => {
+            // if UCI_DIR is present, use it to look for the header file and precompiled libs
+            if let Ok(uci_dir) = env::var("UCI_DIR") {
+                println!("cargo:rustc-link-search=native={}/lib", uci_dir);
+                builder = builder.clang_arg(format!("-I{}/include", uci_dir));
+            } else {
+                panic!(
+                    "vendored is disabled, but UCI_DIR is not set; refusing to build \
              vendored libuci/libubox. Set UCI_DIR to the libuci prefix (with include/ and lib/), \
-             or disable the feature."
-        );
-    } else {
-        // otherwise build it from source
-        let libubox = cmake::Config::new("libubox")
-            .define("BUILD_LUA", "OFF")
-            .define("BUILD_EXAMPLES", "OFF")
-            // Required to build with newer CMake versions (e.g., on Arch Linux)
-            .env("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
-            .build();
-        let libuci = cmake::Config::new("uci")
-            .define("BUILD_LUA", "OFF")
-            .define("BUILD_STATIC", "OFF")
-            .define(
-                "ubox_include_dir",
-                libubox.join("include").as_path().display().to_string(),
-            )
-            .build();
-        println!("cargo:rustc-link-search=native={}/lib", libuci.display());
-        builder = builder.clang_arg(format!("-I{}/include", libuci.display()))
+             or enable the 'vendored' feature."
+                );
+            }
+        }
+        true => {
+            // otherwise build libuci & libubox from source
+            let libubox = cmake::Config::new("libubox")
+                .define("BUILD_LUA", "OFF")
+                .define("BUILD_EXAMPLES", "OFF")
+                // Required to build with newer CMake versions (e.g., on Arch Linux)
+                .env("CMAKE_POLICY_VERSION_MINIMUM", "3.5")
+                .build();
+            let libuci = cmake::Config::new("uci")
+                .define("BUILD_LUA", "OFF")
+                .define("BUILD_STATIC", "OFF")
+                .define(
+                    "ubox_include_dir",
+                    libubox.join("include").as_path().display().to_string(),
+                )
+                .build();
+            println!("cargo:rustc-link-search=native={}/lib", libuci.display());
+            builder = builder.clang_arg(format!("-I{}/include", libuci.display()))
+        }
     }
 
     // Link to libuci and libubox

--- a/libuci-sys/build.rs
+++ b/libuci-sys/build.rs
@@ -10,6 +10,8 @@ use std::{env, fs};
 
 fn main() {
     let out_path = PathBuf::from(env::var("OUT_DIR").unwrap()).join("bindings.rs");
+    let require_system_libuci =
+        env::var_os("CARGO_FEATURE_REQUIRE_SYSTEM_LIBUCI").is_some();
 
     // don't run cmake if running for docs.rs
     if env::var("DOCS_RS").is_ok() {
@@ -27,6 +29,12 @@ fn main() {
     if let Ok(uci_dir) = env::var("UCI_DIR") {
         println!("cargo:rustc-link-search=native={}/lib", uci_dir);
         builder = builder.clang_arg(format!("-I{}/include", uci_dir));
+    } else if require_system_libuci {
+        panic!(
+            "require_system_libuci is enabled, but UCI_DIR is not set; refusing to build \
+             vendored libuci/libubox. Set UCI_DIR to the libuci prefix (with include/ and lib/), \
+             or disable the feature."
+        );
     } else {
         // otherwise build it from source
         let libubox = cmake::Config::new("libubox")

--- a/libuci-sys/src/lib.rs
+++ b/libuci-sys/src/lib.rs
@@ -21,12 +21,9 @@
 //!
 //! ## Vendored
 //!
-//! If no `UCI_DIR` variable is set, rust-uci will compile against the distributed libuci source files licensed under GPLv2.
-//!
-//! ## require_system_libuci feature
-//!
-//! Enabling `require_system_libuci` disables the vendored build and requires `UCI_DIR` to point
-//! at an external libuci/libubox install (with `include/` and `lib/`).
+//! Enable the `vendored` feature to compile against the distributed libuci source files licensed under GPLv2.
+//! If `vendored` is disabled, `UCI_DIR` must point to an external libuci/libubox install
+//! (with `include/` and `lib/`).
 //!
 
 pub use bindings::{

--- a/libuci-sys/src/lib.rs
+++ b/libuci-sys/src/lib.rs
@@ -23,6 +23,11 @@
 //!
 //! If no `UCI_DIR` variable is set, rust-uci will compile against the distributed libuci source files licensed under GPLv2.
 //!
+//! ## require_system_libuci feature
+//!
+//! Enabling `require_system_libuci` disables the vendored build and requires `UCI_DIR` to point
+//! at an external libuci/libubox install (with `include/` and `lib/`).
+//!
 
 pub use bindings::{
     uci_add_delta_path, uci_add_list, uci_add_section, uci_alloc_context, uci_backend, uci_command,

--- a/rust-uci/Cargo.toml
+++ b/rust-uci/Cargo.toml
@@ -21,5 +21,6 @@ thiserror = "2"
 [dev-dependencies]
 tempfile = "3"
 [features]
-# Require dynamic linking from an external libuci/libubox (no vendored build).
-require_system_libuci = ["libuci-sys/require_system_libuci"]
+# Opt into using a vendored libuci build,
+# instead of linking to an external libuci/libubox install.
+vendored = ["libuci-sys/vendored"]

--- a/rust-uci/Cargo.toml
+++ b/rust-uci/Cargo.toml
@@ -20,3 +20,6 @@ thiserror = "2"
 
 [dev-dependencies]
 tempfile = "3"
+[features]
+# Require dynamic linking from an external libuci/libubox (no vendored build).
+require_system_libuci = ["libuci-sys/require_system_libuci"]

--- a/rust-uci/src/lib.rs
+++ b/rust-uci/src/lib.rs
@@ -19,12 +19,9 @@
 //!
 //! ## Vendored
 //!
-//! If no `UCI_DIR` variable is set, rust-uci will compile against the distributed libuci source files licensed under GPLv2.
-//!
-//! ## require_system_libuci feature
-//!
-//! Enabling `require_system_libuci` disables the vendored build and requires `UCI_DIR` to point
-//! at an external libuci/libubox install (with `include/` and `lib/`).
+//! Enable the `vendored` feature to compile against the distributed libuci source files licensed under GPLv2.
+//! If `vendored` is disabled, `UCI_DIR` must point to an external libuci/libubox install
+//! (with `include/` and `lib/`).
 //!
 //! # Example Usage
 //!

--- a/rust-uci/src/lib.rs
+++ b/rust-uci/src/lib.rs
@@ -21,6 +21,11 @@
 //!
 //! If no `UCI_DIR` variable is set, rust-uci will compile against the distributed libuci source files licensed under GPLv2.
 //!
+//! ## require_system_libuci feature
+//!
+//! Enabling `require_system_libuci` disables the vendored build and requires `UCI_DIR` to point
+//! at an external libuci/libubox install (with `include/` and `lib/`).
+//!
 //! # Example Usage
 //!
 //! ```no_run


### PR DESCRIPTION
I am developing a rust application for OpenWRT. I have some trust issues with the dynamic linking feature,
which solely relies on the UCI_DIR environment variable being set during the build, especially with the OpenWRT build system being non-trivial.
That's why, I am proposing to add a new (non-default) feature `require_system_libuci`, which prevents the build script from falling back on building + statically linking libuci. This helps making sure that you don't accidentally link to an LGPL lib statically.