### PR TITLE
switch submodule protocol

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "libuci-sys/libubox"]
 	path = libuci-sys/libubox
-	url = git://git.openwrt.org/project/libubox.git
+	url = https://git.openwrt.org/project/libubox.git
 	ignore = all
 [submodule "libuci-sys/uci"]
 	path = libuci-sys/uci
-	url = git://git.openwrt.org/project/uci.git
+	url = https://git.openwrt.org/project/uci.git
 	ignore = all


### PR DESCRIPTION
Recently, I has issues cloning the submodules of libubox and libuci in my github actions runs.
I propose switching the protocol of the submodules to https.
https is the recommended clone protocol on git.openwrt.org