### PR TITLE
add actions workflow that runs cargo lint, test, and format checks

### DIFF
--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           submodules: recursive
       - uses: actions-rust-lang/setup-rust-toolchain@v1
-      - run: cargo test --features vendored
+      - run: cargo test --all-features
 
   cargo_fmt:
     name: cargo fmt

--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           components: clippy
-      - run: cargo clippy --features vendored
+      - run: cargo clippy --all-features
 
   cargo_test:
     name: cargo test

--- a/.github/workflows/check_and_test.yaml
+++ b/.github/workflows/check_and_test.yaml
@@ -1,0 +1,38 @@
+name: check and test
+on:
+  pull_request:
+
+jobs:
+  cargo_check:
+    name: cargo check (clippy)
+    runs-on: ubuntu-24.04
+    steps:
+      - run: sudo apt update && sudo apt install build-essential cmake libclang-dev libjson-c-dev
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: clippy
+      - run: cargo clippy --features vendored
+
+  cargo_test:
+    name: cargo test
+    runs-on: ubuntu-24.04
+    steps:
+      - run: sudo apt update && sudo apt install build-essential cmake libclang-dev libjson-c-dev
+      - uses: actions/checkout@v6
+        with:
+          submodules: recursive
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+      - run: cargo test --features vendored
+
+  cargo_fmt:
+    name: cargo fmt
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          components: rustfmt
+      - run: cargo fmt --check --verbose


### PR DESCRIPTION
Addresses #5 

Currently, the `cargo test` stage will fail. This should be fixed by #18 .